### PR TITLE
Build with python 3.9 on appveyor

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -8,6 +8,7 @@ environment:
     - PYTHON: 36
     - PYTHON: 37
     - PYTHON: 38
+    - PYTHON: 39
 install:
  - ps: |
       git submodule update -q --init --recursive


### PR DESCRIPTION
I noticed that wheels for python 3.9 on windows are missing on pypi. Is anything else needed in order to generate them?